### PR TITLE
feat: add optional LogLevel parameter to sentry cleanup job

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"clickhouse":"3.9.0","sentry":"23.5.1","sentry-kubernetes":"0.3.4"}
+{"clickhouse":"3.9.0","sentry":"23.5.2","sentry-kubernetes":"0.3.4"}

--- a/sentry/CHANGELOG.md
+++ b/sentry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [23.5.2](https://github.com/sentry-kubernetes/charts/compare/sentry-v23.5.1...sentry-v23.5.2) (2024-06-08)
+
+
+### Bug Fixes
+
+* **snuba:** add profile_chunks to the storage sets ([#1307](https://github.com/sentry-kubernetes/charts/issues/1307)) ([df812f7](https://github.com/sentry-kubernetes/charts/commit/df812f7cf4ba28006a59c0fa49a527feac50a184))
+
 ## [23.5.1](https://github.com/sentry-kubernetes/charts/compare/sentry-v23.5.0...sentry-v23.5.1) (2024-06-07)
 
 

--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 23.5.1
+version: 23.5.2
 appVersion: 24.5.1
 dependencies:
   - name: memcached

--- a/sentry/templates/_helper-snuba.tpl
+++ b/sentry/templates/_helper-snuba.tpl
@@ -41,6 +41,7 @@ settings.py: |
           "spans",
           "group_attributes",
           "generic_metrics_gauges",
+          "profile_chunks",
       },
       {{- /*
         The default clickhouse installation runs in distributed mode, while the external


### PR DESCRIPTION
adding Values.sentry.cleanup.logLevel to make job not silent